### PR TITLE
feat: add tutorings by tutors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import 'primereact/resources/themes/lara-dark-pink/theme.css'
 import DashboardPage from './dashboard/pages/DashboardPage';
 import 'primeicons/primeicons.css';
 import TutoringDetailsPage from './tutoring/pages/TutoringDetailsPage';
+import TutorTutoringsPage from './tutoring/pages/TutorTutoringsPage';
 import TutoringsBySemester from './dashboard/pages/TutoringsBySemester';
 import NotFoundPage from './public/pages/not-found/NotFoundPage';
 import ProfilePage from './public/pages/profile/ProfilePage';
@@ -28,6 +29,7 @@ const App = () => {
           <Route path="/verify-email" element={<VerifyEmailPage />} />
           <Route path="/semester/:semesterId" element={<TutoringsBySemester />} />
           <Route path="/tutoring/:tutoringId" element={<TutoringDetailsPage />} />
+          <Route path="/tutor/:tutorId/tutorings" element={<TutorTutoringsPage />} />
           <Route path="/register/success" element={<RegisterSuccessPage />} />
           <Route path="/profile" element={<ProfilePage />} />
           <Route path="/profile/:userId" element={<ProfilePage />} />

--- a/src/dashboard/pages/DashboardPage.tsx
+++ b/src/dashboard/pages/DashboardPage.tsx
@@ -90,14 +90,22 @@ const DashboardPage: React.FC = () => {
                         {user.role === 'tutor' ? 'Tutor' : 'Estudiante'} • {user.semesterNumber}° Semestre
                       </p>
                       <p className="text-light-gray">{user.academicYear || 'No especificado'}</p>
-                    </div>
-                    <div className="mt-4 md:mt-0">
+                    </div>                    <div className="mt-4 md:mt-0 flex flex-col gap-2">
                       <button
                         className="bg-primary hover:bg-primary-hover text-white px-4 py-2 rounded-md"
                         onClick={() => navigate('/profile')}
                       >
                         Ver perfil
                       </button>
+                      {/* Solo mostrar botón "Ver Tutorías" si el usuario es tutor */}
+                      {user.role === 'tutor' && (
+                        <button
+                          className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-md"
+                          onClick={() => navigate(`/tutor/${user.id}/tutorings`)}
+                        >
+                          Ver Tutorías
+                        </button>
+                      )}
                     </div>
                   </div>
                 </div>

--- a/src/tutoring/components/TutoringDetails.tsx
+++ b/src/tutoring/components/TutoringDetails.tsx
@@ -310,16 +310,25 @@ const TutoringDetails: React.FC<TutoringDetailsProps> = ({
                             cancel={false}
                         />
                         <span className="text-white text-sm">({reviews.length} reseñas)</span>
-                    </div>
-
-                    <div className="flex items-center gap-3 mt-4 mb-4">
+                    </div>                    <div className="flex items-center gap-3 mt-4 mb-4">
                         {tutor && (
                             <>
-                                <div className="flex items-center">
-                                    <Avatar user={tutor} size="sm" className="mr-2" />
-                                    <Link to={`/profile/${tutor.id}`} className="text-red-600 hover:underline">
-                                        {getTutorName()}
-                                    </Link>
+                                <div className="flex items-center gap-4">
+                                    <div className="flex items-center">
+                                        <Avatar user={tutor} size="sm" className="mr-2" />
+                                        <Link to={`/profile/${tutor.id}`} className="text-red-600 hover:underline">
+                                            {getTutorName()}
+                                        </Link>
+                                    </div>
+                                    {/* Solo mostrar botón "Ver Tutorías" si es tutor */}
+                                    {tutor.role === 'tutor' && (
+                                        <Link 
+                                            to={`/tutor/${tutor.id}/tutorings`}
+                                            className="px-3 py-1 bg-green-600 text-white text-sm rounded-md hover:bg-green-700 transition-all"
+                                        >
+                                            Ver Tutorías
+                                        </Link>
+                                    )}
                                 </div>
                             </>
                         )}

--- a/src/tutoring/pages/TutorTutoringsPage.tsx
+++ b/src/tutoring/pages/TutorTutoringsPage.tsx
@@ -1,0 +1,200 @@
+import React, { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { ProgressSpinner } from 'primereact/progressspinner';
+import Navbar from '../../dashboard/components/Navbar';
+import Footer from '../../public/components/Footer';
+import { TutoringService } from '../services/TutoringService';
+import { UserService } from '../../user/services/UserService';
+import { TutoringSession } from '../types/Tutoring';
+import { User } from '../../user/types/User';
+import TutoringCard from '../components/TutoringCard';
+import { useNavigate } from 'react-router-dom';
+import { ArrowLeft, BookOpen, Calendar } from 'lucide-react';
+import Avatar from '../../user/components/Avatar';
+
+const TutorTutoringsPage: React.FC = () => {
+  const { tutorId } = useParams<{ tutorId: string }>();
+  const [tutorings, setTutorings] = useState<TutoringSession[]>([]);
+  const [tutor, setTutor] = useState<User | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        if (!tutorId) {
+          setError('ID de tutor no proporcionado');
+          return;
+        }
+
+        setLoading(true);
+
+        // Obtener información del tutor y sus tutorías en paralelo
+        const [tutorData, tutoringsData] = await Promise.all([
+          UserService.getUserById(tutorId),
+          TutoringService.getTutoringSessionsByTutorId(tutorId)
+        ]);
+
+        setTutor(tutorData);
+        setTutorings(tutoringsData);
+
+      } catch (error: any) {
+        console.error('Error al cargar los datos:', error);
+        setError(error.message || 'Error al cargar las tutorías del tutor');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [tutorId]);
+
+  const handleTutoringClick = (tutoringId: string | number) => {
+    navigate(`/tutoring/${tutoringId}`);
+  };
+
+  const handleBackClick = () => {
+    navigate(-1); // Volver a la página anterior
+  };
+
+  if (loading) {
+    return (
+      <div className="flex flex-col min-h-screen bg-[#1e1e1e] text-white">
+        <div className="fixed top-0 left-0 right-0 z-50">
+          <Navbar />
+        </div>
+        <div className="flex-1 flex items-center justify-center pt-16">
+          <div className="text-center">
+            <ProgressSpinner 
+              style={{ width: '50px', height: '50px' }}
+              strokeWidth="4"
+              fill="#1e1e1e"
+              animationDuration=".5s" 
+            />
+            <p className="text-white mt-4">Cargando tutorías del tutor...</p>
+          </div>
+        </div>
+        <Footer />
+      </div>
+    );
+  }
+
+  if (error || !tutor) {
+    return (
+      <div className="flex flex-col min-h-screen bg-[#1e1e1e] text-white">
+        <div className="fixed top-0 left-0 right-0 z-50">
+          <Navbar />
+        </div>
+        <div className="flex-1 flex items-center justify-center pt-16">
+          <div className="text-center p-6 bg-[#252525] rounded-lg border border-red-500">
+            <h2 className="text-xl text-red-500 mb-4">Error</h2>
+            <p className="text-white">{error || 'No se encontró el tutor solicitado'}</p>
+            <button
+              onClick={handleBackClick}
+              className="mt-4 px-4 py-2 bg-[#f05c5c] text-white rounded-lg hover:bg-[#d14949] transition-all"
+            >
+              Volver
+            </button>
+          </div>
+        </div>
+        <Footer />
+      </div>
+    );
+  }  // Calcular estadísticas del tutor
+  const totalTutorings = tutorings.length;
+
+  return (
+    <div className="flex flex-col min-h-screen bg-[#1e1e1e] text-white">
+      <div className="fixed top-0 left-0 right-0 z-50">
+        <Navbar />
+      </div>
+      
+      <div className="pt-16 flex-1">
+        <div className="container mx-auto px-4 py-8 max-w-6xl">
+          {/* Botón volver */}
+          <button
+            onClick={handleBackClick}
+            className="flex items-center gap-2 mb-6 text-gray-400 hover:text-white transition-colors"
+          >
+            <ArrowLeft size={20} />
+            <span>Volver</span>
+          </button>
+
+          {/* Header del tutor */}
+          <div className="bg-[#252525] rounded-lg p-6 mb-8">
+            <div className="flex flex-col md:flex-row items-center md:items-start gap-6">
+              <div className="flex-shrink-0">
+                <Avatar user={tutor} size="lg" />
+              </div>
+              
+              <div className="flex-1 text-center md:text-left">
+                <h1 className="text-3xl font-bold text-white mb-2">
+                  {tutor.firstName} {tutor.lastName}
+                </h1>
+                <p className="text-gray-400 mb-1">Tutor</p>
+                <p className="text-gray-400 mb-4">
+                  {tutor.semesterNumber}° Semestre • {tutor.academicYear || 'UPC'}
+                </p>
+                
+                {/* Estadísticas */}
+                <div className="flex flex-wrap justify-center md:justify-start gap-6 text-sm">
+                  <div className="flex items-center gap-2">
+                    <BookOpen size={16} className="text-[#f05c5c]" />
+                    <span className="text-gray-300">
+                      {totalTutorings} {totalTutorings === 1 ? 'tutoría' : 'tutorías'}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Calendar size={16} className="text-[#f05c5c]" />
+                    <span className="text-gray-300">
+                      Activo desde {new Date().getFullYear()}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Tutorías del tutor */}
+          <div className="mb-8">
+            <div className="flex justify-between items-center mb-6">
+              <h2 className="text-2xl font-bold text-white">
+                Tutorías ofrecidas por {tutor.firstName}
+              </h2>
+              <span className="text-gray-400 text-sm">
+                {totalTutorings} {totalTutorings === 1 ? 'resultado' : 'resultados'}
+              </span>
+            </div>
+
+            {tutorings.length > 0 ? (
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                {tutorings.map((tutoring) => (
+                  <TutoringCard
+                    key={tutoring.id}
+                    tutoring={tutoring}
+                    onClick={handleTutoringClick}
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className="bg-[#252525] rounded-lg p-8 text-center">
+                <BookOpen size={48} className="text-gray-500 mx-auto mb-4" />
+                <h3 className="text-xl font-medium text-white mb-2">
+                  No hay tutorías disponibles
+                </h3>
+                <p className="text-gray-400">
+                  {tutor.firstName} aún no ha creado ninguna tutoría.
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <Footer />
+    </div>
+  );
+};
+
+export default TutorTutoringsPage;


### PR DESCRIPTION
This pull request introduces a new feature to display a tutor's tutoring sessions and integrates it across multiple parts of the application. The changes include adding a new page (`TutorTutoringsPage`) to view tutor-specific tutorings, updating navigation routes, and enhancing components to include links to this new page.

### New Feature: Tutor-Specific Tutorings Page

* **New file `src/tutoring/pages/TutorTutoringsPage.tsx`:** Implements the `TutorTutoringsPage` component to display tutor-specific tutoring sessions, including tutor details, tutoring statistics, and a list of tutorings. Handles loading states, errors, and navigation.

### Routing Updates

* **`src/App.tsx`:** Added a new route `/tutor/:tutorId/tutorings` to navigate to the `TutorTutoringsPage`.

### Component Enhancements

* **`src/dashboard/pages/DashboardPage.tsx`:** Added a "Ver Tutorías" button for tutor users, linking to their tutoring sessions page.
* **`src/tutoring/components/TutoringDetails.tsx`:** Enhanced the tutoring details view with a "Ver Tutorías" button for tutors, linking to their tutoring sessions page.

### Import Updates

* **`src/App.tsx`:** Imported the new `TutorTutoringsPage` component.